### PR TITLE
Update to support Opera 36+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Add auto-compile support for the Chromium browser.
+* Add auto-compile support for the Chromium  and Opera browsers.
 
 ### Fixed
 * When directory paths don't end in `/`, redirect to the right path, not a

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -148,6 +148,7 @@ function needCompilation(uaParser: UAParser): boolean {
 
   const supportsES2015 = (browser.name === 'Chrome' && majorVersion >= 49) ||
       (browser.name === 'Chromium' && majorVersion >= 49) ||
+      (browser.name === 'Opera' && majorVersion >= 36) ||
       (browser.name === 'Safari' && majorVersion >= 10) ||
       (browser.name === 'Edge' && majorVersion >= 14) ||
       (browser.name === 'Firefox' && majorVersion >= 51);


### PR DESCRIPTION
Opera 36 uses Chromium 49 - http://www.opera.com/docs/history/. If that version is found to be too low, both should be changed.

 - [x] CHANGELOG.md has been updated
